### PR TITLE
Updated options.params handling

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -95,11 +95,9 @@ Strategy.prototype.authenticate = function (req, options) {
 	}
 
 	for (i = 0, len = this._tokenFields.length; !token && i < len; i++) {
-		token = lookup(req.body, this._tokenFields[i], options) || lookup(req.query, this._tokenFields[i], options);
-
-		if (options.params) {
-			token = lookup(req.params, this._tokenFields[i], options);
-		}
+		token = lookup(req.body, this._tokenFields[i], options) ||
+			lookup(req.query, this._tokenFields[i], options) ||
+			(options.params && lookup(req.params, this._tokenFields[i], options));
 	}
 
 	if (!options.optional) {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -90,18 +90,13 @@ Strategy.prototype.authenticate = function (req, options) {
 
 	let i, len, token;
 
-	for (i = 0, len = this._headerFields.length; !token && i < len; i++) {
-		token = lookup(req.headers, this._headerFields[i], options);
+	for (i = 0, len = this._tokenFields.length; !token && i < len; i++) {
+		token = lookup(req.headers, this._headerFields[i], options) ||
+			lookup(req.body, this._tokenFields[i], options) ||
+			lookup(req.query, this._tokenFields[i], options) ||
+			(options.params && lookup(req.params, this._tokenFields[i], options));
 	}
 
-	if (!token) {
-		for (i = 0, len = this._tokenFields.length; !token && i < len; i++) {
-			token = lookup(req.body, this._tokenFields[i], options) ||
-				lookup(req.query, this._tokenFields[i], options) ||
-				(options.params && lookup(req.params, this._tokenFields[i], options));
-		}
-	}
-	
 	if (!options.optional) {
 		if (!token) {
 			return this.fail({

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -90,13 +90,18 @@ Strategy.prototype.authenticate = function (req, options) {
 
 	let i, len, token;
 
-	for (i = 0, len = this._tokenFields.length; !token && i < len; i++) {
-		token = lookup(req.headers, this._headerFields[i], options) ||
-			lookup(req.body, this._tokenFields[i], options) ||
-			lookup(req.query, this._tokenFields[i], options) ||
-			(options.params && lookup(req.params, this._tokenFields[i], options));
+	for (i = 0, len = this._headerFields.length; !token && i < len; i++) {
+		token = lookup(req.headers, this._headerFields[i], options);
 	}
 
+	if (!token) {
+		for (i = 0, len = this._tokenFields.length; !token && i < len; i++) {
+			token = lookup(req.body, this._tokenFields[i], options) ||
+				lookup(req.query, this._tokenFields[i], options) ||
+				(options.params && lookup(req.params, this._tokenFields[i], options));
+		}
+	}
+	
 	if (!options.optional) {
 		if (!token) {
 			return this.fail({

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -94,7 +94,7 @@ Strategy.prototype.authenticate = function (req, options) {
 	const tokenFields = options.tokenFields || this._tokenFields;
 
 	for (i = 0, len = headerFields.length; !token && i < len; i++) {
-		token = lookup(req.headers, this._headerFields[i]);
+		token = lookup(req.headers, headerFields[i]);
 	}
 
 	if (!token) {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -94,12 +94,14 @@ Strategy.prototype.authenticate = function (req, options) {
 		token = lookup(req.headers, this._headerFields[i], options);
 	}
 
-	for (i = 0, len = this._tokenFields.length; !token && i < len; i++) {
-		token = lookup(req.body, this._tokenFields[i], options) ||
-			lookup(req.query, this._tokenFields[i], options) ||
-			(options.params && lookup(req.params, this._tokenFields[i], options));
+	if (!token) {
+		for (i = 0, len = this._tokenFields.length; !token && i < len; i++) {
+			token = lookup(req.body, this._tokenFields[i], options) ||
+				lookup(req.query, this._tokenFields[i], options) ||
+				(options.params && lookup(req.params, this._tokenFields[i], options));
+		}
 	}
-
+	
 	if (!options.optional) {
 		if (!token) {
 			return this.fail({

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -90,15 +90,18 @@ Strategy.prototype.authenticate = function (req, options) {
 
 	let i, len, token;
 
-	for (i = 0, len = this._headerFields.length; !token && i < len; i++) {
-		token = lookup(req.headers, this._headerFields[i], options);
+	const headerFields = options.headerFields || this._headerFields;
+	const tokenFields = options.tokenFields || this._tokenFields;
+
+	for (i = 0, len = headerFields.length; !token && i < len; i++) {
+		token = lookup(req.headers, this._headerFields[i]);
 	}
 
 	if (!token) {
-		for (i = 0, len = this._tokenFields.length; !token && i < len; i++) {
-			token = lookup(req.body, this._tokenFields[i], options) ||
-				lookup(req.query, this._tokenFields[i], options) ||
-				(options.params && lookup(req.params, this._tokenFields[i], options));
+		for (i = 0, len = tokenFields.length; !token && i < len; i++) {
+			token = lookup(req.body, tokenFields[i], options) ||
+				lookup(req.query, tokenFields[i], options) ||
+				(options.params && lookup(req.params, tokenFields[i], options));
 		}
 	}
 	


### PR DESCRIPTION
I've updated `options.params` handling so it _"also includes"_ it in the token check (as described in README), rather than replacing a token value found elsewhere with `undefined` and failing when `options.params = true`, as happens at present.