### PR TITLE
Use HTTPS package metadata URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   "author": "Mike Bell <mbell8903@yahoo.com>",
   "repository": {
     "type": "git",
-    "url": "git://github.com/mbell8903/passport-auth-token.git"
+    "url": "git+https://github.com/mbell8903/passport-auth-token.git"
   },
   "bugs": {
-    "url": "http://github.com/mbell8903/passport-auth-token/issues"
+    "url": "https://github.com/mbell8903/passport-auth-token/issues"
   },
   "licenses": [
     {


### PR DESCRIPTION
Summary
- update package repository metadata from `git://` to `git+https://`
- update the package bug tracker URL from `http://` to `https://`

Validation
- parsed `package.json` and verified the updated repository and bugs URLs
- checked current npm registry metadata for `passport-auth-token@1.0.1`
- `git diff --check`
- `git ls-remote https://github.com/mbell8903/passport-auth-token.git HEAD`